### PR TITLE
Improve test coverage

### DIFF
--- a/test/hash-util.test.ts
+++ b/test/hash-util.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import { promises as fs } from 'fs';
+import { join } from 'path';
+
+// Import with query parameter to avoid mocks from other tests
+import { hashFile } from '../src/utils/hash.ts?actual';
+
+describe('hashFile utility', () => {
+  const dir = '/tmp/hash-test';
+
+  beforeEach(async () => {
+    await fs.mkdir(dir, { recursive: true });
+  });
+
+  afterEach(async () => {
+    await fs.rm(dir, { recursive: true, force: true });
+  });
+
+  it('generates expected SHA-256 hash for known content', async () => {
+    const file = join(dir, 'hello.txt');
+    await fs.writeFile(file, 'hello world');
+    const hash = await hashFile(file);
+    expect(hash).toBe('b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9');
+  });
+});

--- a/test/planner-service.db.test.ts
+++ b/test/planner-service.db.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, beforeEach, afterEach, mock } from 'bun:test';
+import { Database } from 'bun:sqlite';
+import { promises as fs } from 'fs';
+
+const mockLogger = {
+  info: mock(() => Promise.resolve()),
+  error: mock(() => Promise.resolve()),
+  warn: mock(() => Promise.resolve()),
+  debug: mock(() => Promise.resolve()),
+};
+
+const mockConfig = {
+  paths: { logs: '/tmp/test-logs' }
+};
+
+mock.module('../src/utils/logger', () => ({ logger: mockLogger }));
+mock.module('../src/config', () => ({ config: mockConfig }));
+
+let db: Database;
+const mockGetDatabase = mock(() => db);
+
+mock.module('../src/db', () => ({ getDatabase: mockGetDatabase }));
+
+import { plannerService } from '../src/services/planner-service';
+
+describe('PlannerService Database Functions', () => {
+  beforeEach(() => {
+    db = new Database(':memory:');
+    db.run(`CREATE TABLE tasks (id INTEGER PRIMARY KEY, status TEXT)`);
+    db.run(`CREATE TABLE planner_results (
+      id INTEGER PRIMARY KEY,
+      task_id INTEGER,
+      model_used TEXT,
+      goal_description TEXT,
+      generated_plan TEXT,
+      similar_tasks_used TEXT,
+      subtask_count INTEGER,
+      created_at TEXT)`);
+
+    db.run(`INSERT INTO tasks (id, status) VALUES (1, 'completed'), (2, 'failed')`);
+
+    db.run(`INSERT INTO planner_results (task_id, model_used, goal_description, generated_plan, similar_tasks_used, subtask_count, created_at) VALUES
+      (1, 'modelA', 'goal1', 'plan1', '[2]', 3, '2024-01-01T00:00:00Z'),
+      (1, 'modelB', 'goal2', 'plan2', '[]', 4, '2024-01-02T00:00:00Z'),
+      (2, 'modelA', 'goal3', 'plan3', '[1]', 2, '2024-01-03T00:00:00Z'),
+      (2, 'modelA', 'goal4', 'plan4', NULL, 1, '2024-01-04T00:00:00Z')`);
+  });
+
+  afterEach(() => {
+    db.close();
+  });
+
+  it('returns latest planner result for a task', () => {
+    const result = plannerService.getPlannerResultForTask(1);
+    expect(result?.goal_description).toBe('goal2');
+  });
+
+  it('calculates planner metrics correctly', () => {
+    const metrics = plannerService.getPlannerMetrics();
+    expect(metrics.total_plans).toBe(4);
+    expect(metrics.average_subtasks).toBeCloseTo(2.5);
+    expect(metrics.success_rate_by_context.with_similar_tasks).toBe(50);
+    expect(metrics.success_rate_by_context.without_similar_tasks).toBe(50);
+    expect(metrics.most_common_patterns).toEqual(['modelA (3)', 'modelB (1)']);
+  });
+
+  it('retrieves task planner history', () => {
+    const history = plannerService.getTaskPlannerHistory(1);
+    expect(history).toHaveLength(2);
+    expect(history[0].goal_description).toBe('goal2');
+    expect(history[1].goal_description).toBe('goal1');
+  });
+
+  it('retrieves recent planner results', () => {
+    const recent = plannerService.getRecentPlannerResults(3);
+    expect(recent).toHaveLength(3);
+    expect(recent[0].goal_description).toBe('goal4');
+  });
+});

--- a/test/review-service.db.test.ts
+++ b/test/review-service.db.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect, beforeEach, afterEach, mock } from 'bun:test';
+import { Database } from 'bun:sqlite';
+
+const mockLogger = {
+  info: mock(() => Promise.resolve()),
+  error: mock(() => Promise.resolve()),
+  warn: mock(() => Promise.resolve()),
+  debug: mock(() => Promise.resolve()),
+};
+
+const mockConfig = {
+  paths: { logs: '/tmp/test-logs' }
+};
+
+mock.module('../src/utils/logger', () => ({ logger: mockLogger }));
+mock.module('../src/config', () => ({ config: mockConfig }));
+
+let db: Database;
+const mockGetDatabase = mock(() => db);
+
+mock.module('../src/db', () => ({ getDatabase: mockGetDatabase }));
+
+import { reviewService } from '../src/services/review-service';
+
+describe('ReviewService Database Functions', () => {
+  beforeEach(() => {
+    db = new Database(':memory:');
+    db.run(`CREATE TABLE review_results (
+      id INTEGER PRIMARY KEY,
+      task_id INTEGER,
+      passed BOOLEAN,
+      score INTEGER,
+      created_at TEXT)`);
+    db.run(`CREATE TABLE tasks (id INTEGER PRIMARY KEY, status TEXT)`);
+
+    db.run(`INSERT INTO tasks (id, status) VALUES (1, 'completed'), (2, 'failed')`);
+
+    db.run(`INSERT INTO review_results (task_id, passed, score, created_at) VALUES
+      (1, 1, 95, '2024-01-01T00:00:00Z'),
+      (1, 0, 40, '2024-01-02T00:00:00Z'),
+      (2, 1, 80, '2024-01-03T00:00:00Z'),
+      (2, 0, 60, '2024-01-04T00:00:00Z')`);
+  });
+
+  afterEach(() => {
+    db.close();
+  });
+
+  it('summarizes task reviews', () => {
+    const summary = reviewService.getTaskReviewSummary(1);
+    expect(summary.total_reviews).toBe(2);
+    expect(summary.average_score).toBeCloseTo(67.5);
+    expect(summary.passed_count).toBe(1);
+    expect(summary.failed_count).toBe(1);
+    expect(summary.latest_review?.score).toBe(40);
+  });
+
+  it('computes overall review metrics', () => {
+    const metrics = reviewService.getReviewMetrics();
+    expect(metrics.total_reviews).toBe(4);
+    expect(metrics.passed_reviews).toBe(2);
+    expect(metrics.failed_reviews).toBe(2);
+    expect(metrics.average_score).toBeCloseTo(68.75);
+    expect(metrics.score_distribution).toEqual({
+      excellent: 1,
+      good: 1,
+      fair: 1,
+      poor: 1,
+    });
+  });
+
+  it('retrieves task review history', () => {
+    const reviews = reviewService.getTaskReviews(1);
+    expect(reviews).toHaveLength(2);
+    expect(reviews[0].score).toBe(40);
+    expect(reviews[1].score).toBe(95);
+  });
+
+  it('retrieves recent reviews', () => {
+    const recent = reviewService.getRecentReviews(3);
+    expect(recent).toHaveLength(3);
+    expect(recent[0].score).toBe(60);
+  });
+
+  it('badge helpers', () => {
+    expect(reviewService.getPassFailBadge(true)).toContain('PASS');
+    expect(reviewService.getPassFailBadge(false)).toContain('FAIL');
+    expect(reviewService.getScoreBadge(null)).toContain('N/A');
+    expect(reviewService.getScoreBadge(95)).toContain('Excellent');
+    expect(reviewService.getScoreBadge(75)).toContain('Good');
+    expect(reviewService.getScoreBadge(55)).toContain('Fair');
+    expect(reviewService.getScoreBadge(30)).toContain('Poor');
+  });
+});

--- a/test/tool-runner.basic.test.ts
+++ b/test/tool-runner.basic.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect, beforeEach, afterEach, mock } from 'bun:test';
+import { promises as fs } from 'fs';
+import { join } from 'path';
+
+const mockLogger = {
+  info: mock(() => Promise.resolve()),
+  error: mock(() => Promise.resolve()),
+  warn: mock(() => Promise.resolve()),
+  debug: mock(() => Promise.resolve()),
+};
+
+const tempDir = '/tmp/tool-runner-test';
+const mockConfig = {
+  paths: { outputs: tempDir, logs: tempDir },
+};
+
+mock.module('../src/utils/logger', () => ({ logger: mockLogger }));
+mock.module('../src/config', () => ({ config: mockConfig }));
+
+import { toolRunner } from '../src/tools/tool_runner';
+
+describe('ToolRunner Basic Tools', () => {
+  beforeEach(async () => {
+    await fs.mkdir(tempDir, { recursive: true });
+  });
+
+  afterEach(async () => {
+    await fs.rm(tempDir, { recursive: true, force: true });
+  });
+
+  it('reads files using read_file', async () => {
+    const file = join(tempDir, 'read.txt');
+    await fs.writeFile(file, 'hello');
+    const result = await toolRunner.executeTool('read_file', { path: file });
+    expect(result.content).toBe('hello');
+  });
+
+  it('writes files using write_file', async () => {
+    const file = join(tempDir, 'write.txt');
+    const result = await toolRunner.executeTool('write_file', { path: file, content: 'abc' });
+    expect(result.path).toBe(file);
+    const content = await fs.readFile(file, 'utf-8');
+    expect(content).toBe('abc');
+  });
+
+  it('throws for unknown tool', async () => {
+    await expect(toolRunner.executeTool('unknown' as any, {})).rejects.toThrow('Unknown tool');
+  });
+});


### PR DESCRIPTION
## Summary
- create unit tests for planner and review services
- add basic ToolRunner tests
- verify expected hash output

## Testing
- `bun test` *(fails: 232 pass, 231 fail)*

------
https://chatgpt.com/codex/tasks/task_e_6860d179a220832caf415efd789704ad