### PR TITLE
Fix CI workflow to trigger on master branch for Codecov integration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [ main, develop ]
+    branches: [ master, develop ]
   pull_request:
-    branches: [ main, develop ]
+    branches: [ master, develop ]
 
 jobs:
   test:


### PR DESCRIPTION
## Problem
The CI workflow was configured to trigger on `main` and `develop` branches, but this repository uses `master` as the default branch. This meant the CI workflow (including Codecov upload) was never being triggered.

## Solution
Updated the GitHub Actions CI workflow to trigger on `master` and `develop` branches instead of `main` and `develop`.

## Changes
- Updated `.github/workflows/ci.yml` to use `master` branch instead of `main`
- This will allow the CI workflow to run on pushes and pull requests to master
- Codecov coverage reports should now be uploaded successfully

## Testing
Once this PR is merged, the CI workflow should run and upload coverage reports to Codecov.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author