### PR TITLE
Add transcribe executor tests

### DIFF
--- a/test/transcribe-executor.test.ts
+++ b/test/transcribe-executor.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect, beforeEach, afterEach, mock } from 'bun:test';
+import { Database } from 'bun:sqlite';
+import { promises as fs } from 'fs';
+import { join } from 'path';
+
+let db: Database;
+let executeMediaTranscribeTask: (task: any) => Promise<{ success: boolean; error?: string }>;
+const testDir = '/tmp/transcribe-test';
+const mockLogger = {
+    info: mock(() => Promise.resolve()),
+    error: mock(() => Promise.resolve()),
+    warn: mock(() => Promise.resolve()),
+    debug: mock(() => Promise.resolve())
+};
+const mockConfig = {
+    whisper: {
+        model: 'test-model',
+        language: 'en',
+        chunkDuration: 30
+    }
+};
+
+// Set up module mocks before importing executor
+mock.module('../src/utils/logger', () => ({ logger: mockLogger }));
+mock.module('../src/config', () => ({ config: mockConfig }));
+mock.module('../src/db', () => ({ getDatabase: () => db }));
+
+describe('executeMediaTranscribeTask', () => {
+
+beforeEach(async () => {
+    db = new Database(':memory:');
+    db.run(`
+        CREATE TABLE IF NOT EXISTS tasks (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            filename TEXT,
+            file_hash TEXT,
+            parent_id INTEGER,
+            description TEXT,
+            type TEXT,
+            status TEXT,
+            dependencies TEXT,
+            result_summary TEXT,
+            shell_command TEXT,
+            error_message TEXT,
+            args TEXT,
+            generator TEXT,
+            tool TEXT,
+            validation_errors TEXT,
+            created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+            started_at DATETIME,
+            finished_at DATETIME
+        )
+    `);
+    db.run(`
+        CREATE TABLE IF NOT EXISTS media_metadata (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            task_id INTEGER NOT NULL,
+            file_path TEXT NOT NULL,
+            file_hash TEXT NOT NULL UNIQUE,
+            metadata_json TEXT NOT NULL,
+            extracted_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+            tool_used TEXT NOT NULL
+        )
+    `);
+    db.run(`
+        CREATE TABLE IF NOT EXISTS media_transcripts (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            media_id INTEGER NOT NULL,
+            task_id INTEGER NOT NULL,
+            transcript_text TEXT NOT NULL,
+            language TEXT,
+            chunks_json TEXT,
+            whisper_model TEXT NOT NULL,
+            transcribed_at DATETIME DEFAULT CURRENT_TIMESTAMP
+        )
+    `);
+
+    await fs.mkdir(testDir, { recursive: true });
+
+    ({ executeMediaTranscribeTask } = await import('../src/executors/transcribe'));
+});
+
+afterEach(async () => {
+    db.close();
+    await fs.rm(testDir, { recursive: true, force: true });
+});
+
+function createTask(filePath: string) {
+    db.run(`INSERT INTO tasks (id, type, description, status) VALUES (1, 'media_transcribe', 'test', 'pending')`);
+    return { id: 1, type: 'media_transcribe', description: 'test', file_path: filePath, status: 'pending', result: null };
+}
+
+it('returns error when media metadata missing', async () => {
+    const filePath = join(testDir, 'audio.mp3');
+    await fs.writeFile(filePath, 'data');
+    const task = createTask(filePath);
+
+    const result = await executeMediaTranscribeTask(task);
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('Media metadata not found');
+});
+
+it('skips when already transcribed', async () => {
+    const filePath = join(testDir, 'skip.mp3');
+    await fs.writeFile(filePath, 'data');
+    const task = createTask(filePath);
+
+    db.run(`INSERT INTO media_metadata (id, task_id, file_path, file_hash, metadata_json, tool_used) VALUES (1, 1, ?, 'hash', '{}', 'ffprobe')`, [filePath]);
+    db.run(`INSERT INTO media_transcripts (media_id, task_id, transcript_text, language, chunks_json, whisper_model) VALUES (1, 1, 'Existing', 'en', '[]', 'test-model')`);
+
+    const result = await executeMediaTranscribeTask(task);
+    expect(result.success).toBe(true);
+});
+
+it('stores transcript when successful', async () => {
+    const filePath = join(testDir, 'file.mp3');
+    await fs.writeFile(filePath, 'data');
+    const task = createTask(filePath);
+
+    db.run(`INSERT INTO media_metadata (id, task_id, file_path, file_hash, metadata_json, tool_used) VALUES (1, 1, ?, 'hash', '{"meta":true}', 'ffprobe')`, [filePath]);
+
+    const tempDir = join(testDir, '.whisper_temp');
+    await fs.mkdir(tempDir, { recursive: true });
+    const outputFile = join(tempDir, 'file.json');
+    await fs.writeFile(outputFile, JSON.stringify({ text: 'hello world', language: 'en', segments: [{ start: 0, end: 1, text: 'hello' }, { start: 1, end: 2, text: 'world' }] }));
+
+    const result = await executeMediaTranscribeTask(task);
+
+    expect(result.success).toBe(true);
+    const row = db.prepare('SELECT transcript_text FROM media_transcripts WHERE media_id = 1').get() as any;
+    expect(row.transcript_text).toBe('hello world');
+});
+
+});


### PR DESCRIPTION
## Summary
- add unit tests for the media transcribe executor

## Testing
- `bun test test/transcribe-executor.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_686493cc8c30832c8907d236c9a52ba9